### PR TITLE
Version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This plugin also supports using the GraphQL source plugin. This requires a bit m
 | `query` | A GraphQL query that will return all the data needed for the `searchFields` as well as any extra node data. |
 | `path` | The path to the nodes array data returned from the GraphQL Query, using any [Lodash Get](https://lodash.com/docs/4.17.15#get) methods. |
 
-An example of this setup is shown below, using the [GraphQL source plugin](https://gridsome.org/plugins/@gridsome/source-graphql) with [WPGraphql](https://www.wpgraphql.com):
+An example of this setup is shown below, using the [GraphQL source plugin](https://gridsome.org/plugins/@gridsome/source-graphql) with [WPGraphQL](https://www.wpgraphql.com):
 
 `gridsome.config.js`
 ```js

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # gridsome-plugin-flexsearch
 
-> Add lightning fast search to Gridsome with FlexSearch
-
-*Demo: https://gridsome-shopify-starter.netlify.app*
+> Add lightning fast search to Gridsome with FlexSearch - [demo](https://gridsome-shopify-starter.netlify.app)
 
 Table of contents:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Next, you need to specify what types you want to add to the index with `collecti
 Fields will be returned with the search result under a `node` key, so for example you could include a product title, slug, and image to show the product name & image in the search result, and add a link to the relevant page.
 
 An example setup is shown below, assuming there is a `Post` and a `Collection` type:
+
 `gridsome.config.js`
 ```js
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -2,31 +2,41 @@
 
 > Add lightning fast search to Gridsome with FlexSearch
 
+- [gridsome-plugin-flexsearch](#gridsome-plugin-flexsearch)
+  * [Installation](#installation)
+  * [Configuration](#configuration)
+    + [GraphQL Source](#graphql-source)
+    + [Additional Options](#additional-options)
+  * [Usage](#usage)
+
 ## Installation
 
-_Requires at least Gridsome `v0.7.3`, versions `>= 0.1.20` requires Gridsome > `0.7.14`._
+_Requires at least Gridsome `v0.7.3`, versions `>= 0.1.21` requires Gridsome > `0.7.15`._
 
 ```bash
-yarn add gridsome-plugin-flexsearch #or
+yarn add gridsome-plugin-flexsearch # or
 npm i gridsome-plugin-flexsearch
 ```
 
 `gridsome.config.js`
 ```js
 module.exports = {
-  {
-    use: 'gridsome-plugin-flexsearch',
-    options: {
-      collections: [
-        {
-          typeName: 'SomeType',
-          indexName: 'SomeType',
-          fields: ['title', 'handle', 'description']
-        }
-      ],
-      searchFields: ['title']
+  // ...
+  plugins: [
+    {
+      use: 'gridsome-plugin-flexsearch',
+      options: {
+        searchFields: ['title'],
+        collections: [
+          {
+            typeName: 'SomeType',
+            indexName: 'SomeType',
+            fields: ['title', 'handle', 'description']
+          }
+        ]
+      }
     }
-  }
+  ]
 }
 ```
 
@@ -34,15 +44,7 @@ module.exports = {
 
 This plugin requires a few configurations to get going.
 
-Firstly, you need to specify what types you want to add to the index with `collections: [...`. `collections` expects an array of objects, each with at least two fields, and one optional field.
-
-| Option  | Explanation |
-| ------------- | ------------- |
-| `typeName`  | The Schema typename - e.g. `Post`. All nodes with this typename will be added to the search index.  |
-| `indexName`  | The name of the index created for this collection - can be the same as `typeName`.  |
-| `fields` | An array of keys that will be extracted from each node, and added to the search index doc (what the search result will return when queried).
-
-Now you will need to add the fields that will be included in the index, and searched. Note that this is different from the above `fields` option, as fields will not be searched, they are just what is returned in each result.
+Firstly, you will need to add the fields that will be included in the index and searched. Note that this is different from the below `fields` option, as fields will not be searched - they are just what is returned in each result.
 
 | Option | Explanation |
 | ---------- | --------|
@@ -51,6 +53,85 @@ Now you will need to add the fields that will be included in the index, and sear
 You can also specify optional flexsearch configurations under a `flexsearch` key - the default configuration is to use the `default` profile, which will setup the FlexSearch instance with some sensible defaults.
 However you can override this profile, or set custom options such as `tokenize`, `resolution` etc. Read the [FlexSearch](https://github.com/nextapps-de/flexsearch#presets) docs to find out more.
 
+Next, you need to specify what types you want to add to the index with `collections: [...`. `collections` expects an array of objects, each with at least two fields, and one optional field.
+
+| Option | Explanation |
+| ------------- | ------------- |
+| `typeName` | The Schema typename - e.g. `Post`. All nodes with this typename will be added to the search index. |
+| `indexName` | The name of the index created for this collection - can be the same as `typeName`. It is added to the result, so you can differentiate between `Collection` & `Product` search results for example. |
+| `fields` | An array of keys that will be extracted from each node, and added to the search index doc (what the search result will return when queried). |
+
+Fields will be returned with the search result under a `node` key, so for example you could include a product title, slug, and image to show the product name & image in the search result, and add a link to the relevant page.
+
+An example setup is shown below, assuming there is a `Post` and a `Collection` type:
+`gridsome.config.js`
+```js
+module.exports = {
+  // ...
+  plugins: [
+    {
+      use: 'gridsome-plugin-flexsearch',
+      options: {
+        searchFields: ['title', 'tags'],
+        collections: [
+          {
+            typeName: 'Post'
+            indexName: 'Post',
+            fields: ['id', 'title', 'path', 'image']
+          },
+          {
+            typeName: 'Collection'
+            indexName: 'Collection',
+            fields: ['id', 'title', 'path']
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### GraphQL Source
+
+This plugin also supports using the GraphQL source plugin. This requires a bit more setup however, as you will need to specify the GraphQL query that will return nodes you want to search, and the path to that data in the query.
+
+| Option | Explanation |
+| ------------- | ------------- |
+| `indexName` | The name of the index created for this collection - can be the same as `typeName`. It is added to the result, so you can differentiate between `Collection` & `Product` search results for example. |
+| `query` | A GraphQL query that will return all the data needed for the `searchFields` as well as any extra node data. |
+| `path` | The path to the nodes array data returned from the GraphQL Query, using any [Lodash Get](https://lodash.com/docs/4.17.15#get) methods. |
+
+An example of this setup is shown below, using the [GraphQL source plugin](https://gridsome.org/plugins/@gridsome/source-graphql) with [WPGraphql](https://www.wpgraphql.com):
+
+`gridsome.config.js`
+```js
+module.exports = {
+  // ...
+  plugins: [
+    {
+      use: '@gridsome/source-graphql',
+      options: {
+        url: 'https://somesite.com/graphql',
+        fieldName: 'wordpress',
+        typeName: 'Wordpress'
+      }
+    },
+    {
+      use: 'gridsome-plugin-flexsearch',
+      options: {
+        searchFields: ['title', 'excerpt'],
+        collections: [
+          {
+            indexName: 'Product',
+            query: `{ wordpress { posts { nodes { id, title, uri, excerpt, description, featuredImage { altText, sourceUrl } } } } }`,
+            path: 'wordpress.posts.nodes'
+          }
+        ]
+      }
+    }
+  ]
+}
+```
 
 ### Additional Options
 
@@ -60,17 +141,20 @@ However you can override this profile, or set custom options such as `tokenize`,
 | `compress` | Defaults to false. If you have a large amount of data (5k+ nodes) you can compress this data to substantially decrease the JSON size. Note that this may actually _increase_ the JSON size if you have a small amount of data, due to the way compression works. |
 | `autoFetch` | Defaults to true. This plugin will usually automatically fetch and import the generated FlexSearch index & docs as soon as the site is loaded, but if you only want this to happen on a certain route to reduce other page load times for example (i.e. `/search`), you can specify that route with this option, or disable it completely and import yourself with `this.$search/import({ ...`] |
 
-#### Examples
+Some examples of these configurations are shown below:
+`gridsome.config.js`
 ```js
-...
+// ...
 options: {
   chunk: true,
+  compress: true,
   autoFetch: '/search',
   // Or
   chunk: 1000,
-  autoFetch: ['/search', '/collections']
+  autoFetch: ['/search', '/collections'],
+  // ...
 }
-...
+// ...
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 > Add lightning fast search to Gridsome with FlexSearch
 
-- [gridsome-plugin-flexsearch](#gridsome-plugin-flexsearch)
-  * [Installation](#installation)
-  * [Configuration](#configuration)
-    + [GraphQL Source](#graphql-source)
-    + [Additional Options](#additional-options)
-  * [Usage](#usage)
+1. [Installation](#installation)
+2. [Configuration](#configuration)
+  + [GraphQL Source](#graphql-source)
+  + [Additional Options](#additional-options)
+3. [Usage](#usage)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 2. [Configuration](#configuration)
   + [GraphQL Source](#graphql-source)
   + [Additional Options](#additional-options)
+  + [FlexSearch Options](#flexsearch-options)
 3. [Usage](#usage)
 
 ## Installation
@@ -142,6 +143,7 @@ module.exports = {
 | `autoFetch` | Defaults to true. This plugin will usually automatically fetch and import the generated FlexSearch index & docs as soon as the site is loaded, but if you only want this to happen on a certain route to reduce other page load times for example (i.e. `/search`), you can specify that route with this option, or disable it completely and import yourself with `this.$search/import({ ...`] |
 
 Some examples of these configurations are shown below:
+
 `gridsome.config.js`
 ```js
 // ...
@@ -152,6 +154,23 @@ options: {
   // Or
   chunk: 1000,
   autoFetch: ['/search', '/collections'],
+  // ...
+}
+// ...
+```
+
+### FlexSearch Options
+
+Custom FlexSearch options can be configured under the `flexsearch` key, for example setting default profiles, or adding custom matchers/encoders.
+
+`gridsome.config.js`
+```js
+// ...
+options: {
+  flexsearch: {
+    cache: true,
+    profile: 'match'
+  }
   // ...
 }
 // ...

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ However you can override this profile, or set custom options such as `tokenize`,
 | Option | Explanation |
 | ---------- | --------|
 | `chunk` | Defaults to false. If `true` or a Number (docs array chunk size), it will split up the FlexSearch index & docs JSON file to reduce filesizes - useful if you have a huge amount of data. |
+| `compress` | Defaults to false. If you have a large amount of data (5k+ nodes) you can compress this data to substantially decrease the JSON size. Note that this may actually _increase_ the JSON size if you have a small amount of data, due to the way compression works. |
 | `autoFetch` | Defaults to true. This plugin will usually automatically fetch and import the generated FlexSearch index & docs as soon as the site is loaded, but if you only want this to happen on a certain route to reduce other page load times for example (i.e. `/search`), you can specify that route with this option, or disable it completely and import yourself with `this.$search/import({ ...`] |
 
 #### Examples
@@ -65,7 +66,7 @@ However you can override this profile, or set custom options such as `tokenize`,
 options: {
   chunk: true,
   autoFetch: '/search',
-  # OR
+  // Or
   chunk: 1000,
   autoFetch: ['/search', '/collections']
 }

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -1,14 +1,17 @@
-const path = require('path')
-const fs = require('fs')
+const _chunk = require('lodash.chunk')
 const cjson = require('compressed-json')
 const FlexSearch = require('flexsearch')
+const fs = require('fs')
+const path = require('path')
+const pMap = require('p-map')
 const { v4: uuid } = require('uuid')
-const _chunk = require('lodash.chunk')
 
 function CreateSearchIndex (api, options) {
+  // Setup defaults
   const { searchFields = [], collections = [], flexsearch = {}, chunk = false } = options
   const { profile = 'default', ...flexoptions } = flexsearch
 
+  // Create base FlexSearch instance
   const search = new FlexSearch({
     profile,
     ...flexoptions,
@@ -18,9 +21,11 @@ function CreateSearchIndex (api, options) {
     }
   })
 
+  // Set client options
   const clientOptions = { pathPrefix: api._app.config._pathPrefix, siteUrl: api._app.config.siteUrl, ...options }
   api.setClientOptions(clientOptions)
 
+  // Simple function to get Node from store, and remove internal refs
   function getNode ({ typeName, id }) {
     const node = api._app.store.getNode(typeName, id)
     delete node.$loki
@@ -28,6 +33,7 @@ function CreateSearchIndex (api, options) {
     return node
   }
 
+  // Functions to recursively fetch relations, and normalize data
   function parseArray (array, stringify = true) {
     const [firstItem] = array
     if (firstItem && firstItem.typeName) return array.map(node => getNode(node))
@@ -42,46 +48,87 @@ function CreateSearchIndex (api, options) {
     return Object.entries(object).reduce((obj, [key, value]) => ({ ...obj, [ key ]: parseObject(value) }), {})
   }
 
-  api.onBootstrap(async () => {
-    const docs = collections.flatMap(collection => {
-      const collectionStore = api._app.store.getCollection(collection.typeName)
-      if (!collectionStore) return
+  // Function to get collection from store, and transform nodes
+  function getStoreCollection (collection) {
+    const collectionStore = api._app.store.getCollection(collection.typeName)
+    if (!collectionStore) return
+    return collectionStore.data().map(node => {
+      delete node.$loki
+      delete node.$uid
+      // Fields that will be indexed, so must be included & flattened etc
+      const indexFields = searchFields.reduce((obj, key) => {
+        const value = node[ key ]
+        if (!value) return { [ key ]: value, ...obj }
+        if (typeof value === 'object') return { [ key ]: parseObject(value), ...obj }
+        return { [ key ]: value, ...obj }
+      }, {})
+      console.log(indexFields)
 
-      return collectionStore.data().map(node => {
-        delete node.$loki
-        delete node.$uid
-        // Fields that will be indexed, so must be included & flattened etc
-        const indexFields = searchFields.reduce((obj, key) => {
-          const value = node[ key ]
-          if (!value) return { [ key ]: value, ...obj }
-          if (typeof value === 'object') return { [ key ]: parseObject(value), ...obj }
-          return { [ key ]: value, ...obj }
-        }, {})
+      // The doc fields that will be returned with the search result
+      // We can either return just the fields a user has chosen, or return the whole node
+      const docFields = collection.fields ? collection.fields.map(field => [field, node[ field ]]) : Object.entries(node)
+      // Get any relations
+      const doc = Object.fromEntries(docFields.map(([key, value]) => {
+        if (!value) return [key, value]
+        if (typeof value === 'object') return [key, parseObject(value, false)]
+        return [key, value]
+      }))
+      console.log(doc)
 
-        // The doc fields that will be returned with the search result
-        // We can either return just the fields a user has chosen, or return the whole node
-        const docFields = collection.fields ? collection.fields.map(field => [field, node[ field ]]) : Object.entries(node)
-        // Get any relations
-        const doc = Object.fromEntries(docFields.map(([key, value]) => {
-          if (!value) return [key, value]
-          if (typeof value === 'object') return [key, parseObject(value, false)]
-          return [key, value]
-        }))
-
-        return {
-          index: collection.indexName,
-          id: node.id,
-          path: node.path,
-          node: doc,
-          ...indexFields
-        }
-      })
+      return {
+        index: collection.indexName,
+        id: node.id,
+        path: node.path,
+        node: doc,
+        ...indexFields
+      }
     })
-    search.add(docs)
+  }
 
+  // Function to get collection from GraphQL server (using internal remote schema) and transform nodes
+  async function getGraphQLCollection ({ indexName, fields, graphql: path }) {
+    const singleFields = fields.filter(field => typeof field === 'string')
+    const nestedFields = fields.filter(field => typeof field === 'object').map(([field, ...fields]) => `${field} { id ${fields.join(' ')} }`)
+
+    // Create the GraphQL query, joining the fields and path together
+    const query = path.split('.').reverse().reduce((q, key) => `${key} { `.concat(q).concat(` }`), `id ${[...singleFields, ...nestedFields].join(' ')}`)
+
+    // Query data, throw errors, then get the nodes with the provided path
+    const { data, errors } = await api._app.graphql(`{ ${query}}`)
+    if (errors) return console.log(errors[ 0 ])
+    const nodes = path.split('.').reduce((obj, key) => obj[ key ], data)
+
+    return nodes.map(node => {
+      // Fields that will be indexed, so must be included & flattened etc
+      const indexFields = searchFields.reduce((obj, key) => {
+        const value = node[ key ]
+        if (!value) return { [ key ]: value, ...obj }
+        if (typeof value === 'object') return { [ key ]: parseObject(value), ...obj }
+        return { [ key ]: value, ...obj }
+      }, {})
+
+      return {
+        index: indexName,
+        id: node.id,
+        path: node.path,
+        node,
+        ...indexFields
+      }
+    })
+  }
+  api.onBootstrap(async () => {
+    // Map over collections, and either fetch from remote graphql, or local store. Then flatten the received arrays.
+    const docs = (await pMap(collections, async collection => {
+      if (collection.graphql) return getGraphQLCollection(collection)
+      return getStoreCollection(collection)
+    })).flat()
+
+    // Add to search index
+    search.add(docs)
     console.log(`Added ${docs.length} nodes to Search Index`)
   })
 
+  // Setup an endpoint for the dev server
   api.configureServer(app => {
     console.log('Serving search index...')
     if (chunk) {
@@ -103,6 +150,7 @@ function CreateSearchIndex (api, options) {
     }
   })
 
+  // Create the manifest and save to disk on build
   api.afterBuild(async ({ config }) => {
     const outputDir = config.outputDir || config.outDir
 
@@ -132,6 +180,7 @@ function CreateSearchIndex (api, options) {
     }
   })
 
+  // Create a manifest, that declares the index location(s)
   function createManifest () {
     const searchIndex = search.export({ serialize: false, index: true, doc: false })
     const [searchDocs] = search.export({ serialize: false, index: false, doc: true })

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -57,7 +57,8 @@ function CreateSearchIndex (api, options) {
       delete node.$loki
       delete node.$uid
       // Fields that will be indexed, so must be included & flattened etc
-      const indexFields = searchFields.reduce((obj, key) => {
+      const searchFieldKeys = Array.isArray(searchFields) ? searchFields : Object.keys(searchFields)
+      const indexFields = searchFieldKeys.reduce((obj, key) => {
         const value = node[ key ]
         if (!value) return { [ key ]: value, ...obj }
         if (typeof value === 'object') return { [ key ]: parseObject(value), ...obj }
@@ -94,7 +95,8 @@ function CreateSearchIndex (api, options) {
 
     return nodes.map(node => {
       // Fields that will be indexed, so must be included & flattened etc
-      const indexFields = searchFields.reduce((obj, key) => {
+      const searchFieldKeys = Array.isArray(searchFields) ? searchFields : Object.keys(searchFields)
+      const indexFields = searchFieldKeys.reduce((obj, key) => {
         const value = node[ key ]
         if (!value) return { [ key ]: value, ...obj }
         if (typeof value === 'object') return { [ key ]: parseObject(value), ...obj }

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -116,6 +116,7 @@ function CreateSearchIndex (api, options) {
       }
     })
   }
+
   api.onBootstrap(async () => {
     // Map over collections, and either fetch from remote graphql, or local store. Then flatten the received arrays.
     const docs = (await pMap(collections, async collection => {

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -7,7 +7,7 @@ const path = require('path')
 const pMap = require('p-map')
 const { v4: uuid } = require('uuid')
 
-function FlexSearch (api, options) {
+function FlexSearchIndex (api, options) {
   // Setup defaults
   const { searchFields = [], collections = [], flexsearch = {}, chunk = false, compress = false } = options
   const { profile = 'default', ...flexoptions } = flexsearch
@@ -218,7 +218,7 @@ function FlexSearch (api, options) {
   }
 }
 
-module.exports = FlexSearch
+module.exports = FlexSearchIndex
 
 module.exports.defaultOptions = () => ({
   chunk: false,

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -7,7 +7,7 @@ const path = require('path')
 const pMap = require('p-map')
 const { v4: uuid } = require('uuid')
 
-function CreateSearchIndex (api, options) {
+function FlexSearch (api, options) {
   // Setup defaults
   const { searchFields = [], collections = [], flexsearch = {}, chunk = false, compress = false } = options
   const { profile = 'default', ...flexoptions } = flexsearch
@@ -218,7 +218,7 @@ function CreateSearchIndex (api, options) {
   }
 }
 
-module.exports = CreateSearchIndex
+module.exports = FlexSearch
 
 module.exports.defaultOptions = () => ({
   chunk: false,

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -62,7 +62,6 @@ function CreateSearchIndex (api, options) {
         if (typeof value === 'object') return { [ key ]: parseObject(value), ...obj }
         return { [ key ]: value, ...obj }
       }, {})
-      console.log(indexFields)
 
       // The doc fields that will be returned with the search result
       // We can either return just the fields a user has chosen, or return the whole node
@@ -73,7 +72,6 @@ function CreateSearchIndex (api, options) {
         if (typeof value === 'object') return [key, parseObject(value, false)]
         return [key, value]
       }))
-      console.log(doc)
 
       return {
         index: collection.indexName,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "core-js": "^3.6.5",
     "flexsearch": "^0.6.32",
     "lodash.chunk": "^4.2.0",
-    "uuid": "^7.0.3"
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "eslint-config-travisreynolds-node": "1.1.8"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash.get": "^4.4.2",
     "p-map": "^4.0.0",
     "regenerator-runtime": "^0.13.5",
-    "uuid": "^8.0.0"
+    "uuid": "^8.1.0"
   },
   "devDependencies": {
     "eslint-config-travisreynolds-node": "1.1.8"

--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
   ],
   "dependencies": {
     "compressed-json": "^1.0.15",
-    "core-js": "2",
+    "core-js": "^3.6.5",
     "flexsearch": "^0.6.32",
     "lodash.chunk": "^4.2.0",
-    "regenerator-runtime": "^0.13.5",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "core-js": "^3.6.5",
     "flexsearch": "^0.6.32",
     "lodash.chunk": "^4.2.0",
+    "lodash.get": "^4.4.2",
     "p-map": "^4.0.0",
     "regenerator-runtime": "^0.13.5",
     "uuid": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "core-js": "^3.6.5",
     "flexsearch": "^0.6.32",
     "lodash.chunk": "^4.2.0",
+    "p-map": "^4.0.0",
+    "regenerator-runtime": "^0.13.5",
     "uuid": "^8.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-flexsearch",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Add lightning fast search to Gridsome with FlexSearch",
   "main": "gridsome.server.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "regenerator-runtime": "^0.13.5",
     "uuid": "^8.1.0"
   },
+  "peerDependencies": {
+    "gridsome": ">=0.7.15"
+  },
   "devDependencies": {
     "eslint-config-travisreynolds-node": "1.1.8"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-flexsearch",
-  "version": "0.1.20",
+  "version": "1.0.0-beta",
   "description": "Add lightning fast search to Gridsome with FlexSearch",
   "main": "gridsome.server.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-flexsearch",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "description": "Add lightning fast search to Gridsome with FlexSearch",
   "main": "gridsome.server.js",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,14 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
+aggregate-error@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 ajv@^6.10.0, ajv@^6.10.2:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
@@ -231,6 +239,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -755,6 +768,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1056,6 +1074,13 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -1145,6 +1170,11 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+regenerator-runtime@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regexpp@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,10 +1460,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
-  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
+uuid@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,10 +1425,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+uuid@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,10 +283,10 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
-core-js@2:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+core-js@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -1145,11 +1145,6 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
-
-regenerator-runtime@^0.13.5:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regexpp@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,6 +935,11 @@ lodash.chunk@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
   integrity sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"


### PR DESCRIPTION
This version 1.0.0 release has a few updates, that will most likely encur breaking changes to sites, hence the major version bump. These include:

- Moving a docs data to a node field, to avoid fields being stringified or otherwise manipulated if needed as a search field; fixes #38 
- Changing the ID to use a generated uuid, to fix #34 
- Add optional compression to fix #39 

It also requires the latest version of Gridsome (v0.7.15 at time of writing) as it uses the `onBootstrap` hook to fetch data _after_ the store has loaded, instead of using the `onCreateNode` hook which could cause problems as it didn't necessarily run last in the chain, meaning the node wouldn't have any manual updates made in another `onCreateNode` hook.